### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,5 +1,8 @@
 name: Security & Dependency Updates
 
+permissions:
+  contents: read
+
 on:
   schedule:
     # Run every Monday at 9 AM UTC
@@ -10,6 +13,9 @@ jobs:
   security-audit:
     name: Security Audit
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     
     steps:
     - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/CaviraOSS/neuropilot/security/code-scanning/3](https://github.com/CaviraOSS/neuropilot/security/code-scanning/3)

To fix the problem, you should explicitly set the `permissions` block in your workflow. Add it at the root of the workflow to set a default minimum (e.g., `contents: read`), and override it for jobs that need additional privileges. In this workflow:
- Add `permissions: contents: read` at the top level, which gives read-only access to code.
- For `security-audit`, add `permissions` set to `contents: read`, `issues: write` so it can create GitHub issues.
- For `dependency-updates`, no override is needed unless it requires more than `contents: read`.
This change should be made in `.github/workflows/security.yml` at the beginning (top-level keys), and just below the `security-audit:` job when that job's permissions need write access.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
