### PR TITLE
feat: add MiniMax as 7th LLM provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,7 +20,7 @@ db_mode=json
 ########################################
 # LLM Core Settings
 ########################################
-LLM_PROVIDER=gemini            # gemini | openai | claude | grok | ollama | openrouter
+LLM_PROVIDER=gemini            # gemini | openai | claude | grok | ollama | openrouter | minimax
 EMB_PROVIDER=openai             # openai | gemini | ollama etc.
 LLM_TEMP=1
 LLM_MAXTOK=16384
@@ -61,6 +61,12 @@ OPENROUTER_MODEL=google/gemini-2.5-flash
 XAI_API_KEY=sk-xai-xxxx
 GROK_MODEL=grok-2-latest
 GROK_BASE=https://api.x.ai/v1
+
+########################################
+# MiniMax
+########################################
+MINIMAX_API_KEY=
+MINIMAX_MODEL=MiniMax-M2.7
 
 ########################################
 # Ollama (local models)

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The platform provides a modern interface for students, educators, and researcher
 
 ### Supported AI Models
 
-- Google Gemini • OpenAI GPT • Anthropic Claude • xAI Grok • Ollama (local) • OpenRouter
+- Google Gemini • OpenAI GPT • Anthropic Claude • xAI Grok • [MiniMax](https://www.minimax.io/) • Ollama (local) • OpenRouter
 
 ### Embedding Providers
 

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -22,6 +22,8 @@ export const config = {
   grok: process.env.XAI_API_KEY || '',
   grok_model: process.env.GROK_MODEL || 'grok-2-latest',
   grok_base: process.env.GROK_BASE || 'https://api.x.ai/v1',
+  minimax: process.env.MINIMAX_API_KEY || '',
+  minimax_model: process.env.MINIMAX_MODEL || 'MiniMax-M2.7',
   ollama: {
     model: process.env.OLLAMA_MODEL || 'llama4',
     embedModel: process.env.OLLAMA_EMBED_MODEL || '',

--- a/backend/src/utils/llm/models/__tests__/minimax-factory.test.ts
+++ b/backend/src/utils/llm/models/__tests__/minimax-factory.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock all provider modules
+vi.mock('../ollama', () => ({ makeLLM: vi.fn(), makeEmbeddings: vi.fn() }))
+vi.mock('../gemini', () => ({ makeLLM: vi.fn(), makeEmbeddings: vi.fn() }))
+vi.mock('../openai', () => ({
+  makeLLM: vi.fn().mockReturnValue({ invoke: vi.fn(), call: vi.fn() }),
+  makeEmbeddings: vi.fn().mockReturnValue({ embedDocuments: vi.fn(), embedQuery: vi.fn() }),
+}))
+vi.mock('../grok', () => ({ makeLLM: vi.fn(), makeEmbeddings: vi.fn() }))
+vi.mock('../claude', () => ({ makeLLM: vi.fn(), makeEmbeddings: vi.fn() }))
+vi.mock('../openrouter', () => ({ makeLLM: vi.fn(), makeEmbeddings: vi.fn() }))
+vi.mock('../minimax', () => ({
+  makeLLM: vi.fn().mockReturnValue({ invoke: vi.fn(), call: vi.fn() }),
+  makeEmbeddings: vi.fn().mockReturnValue({
+    embedDocuments: vi.fn(),
+    embedQuery: vi.fn(),
+  }),
+}))
+
+// Mock config
+vi.mock('../../../../config/env', () => ({
+  config: { provider: 'minimax', embeddings_provider: '' },
+}))
+
+import { makeModels } from '../index'
+import * as minimax from '../minimax'
+import { config } from '../../../../config/env'
+
+describe('Factory integration – MiniMax provider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should select MiniMax provider when config.provider is "minimax"', () => {
+    ;(config as any).provider = 'minimax'
+    const { llm, embeddings } = makeModels()
+
+    expect(minimax.makeLLM).toHaveBeenCalledWith(config)
+    expect(minimax.makeEmbeddings).toHaveBeenCalledWith(config)
+    expect(llm).toBeDefined()
+    expect(embeddings).toBeDefined()
+  })
+
+  it('should fallback to embeddings_provider when MiniMax embeddings throw', () => {
+    ;(config as any).provider = 'minimax'
+    ;(config as any).embeddings_provider = 'openai'
+    ;(minimax.makeEmbeddings as ReturnType<typeof vi.fn>).mockImplementationOnce(() => {
+      throw new Error('No OpenAI key')
+    })
+
+    const { llm, embeddings } = makeModels()
+
+    expect(minimax.makeLLM).toHaveBeenCalled()
+    expect(llm).toBeDefined()
+    expect(embeddings).toBeDefined()
+  })
+
+  it('should not select MiniMax when provider is "openai"', () => {
+    ;(config as any).provider = 'openai'
+    makeModels()
+
+    expect(minimax.makeLLM).not.toHaveBeenCalled()
+  })
+})

--- a/backend/src/utils/llm/models/__tests__/minimax-integration.test.ts
+++ b/backend/src/utils/llm/models/__tests__/minimax-integration.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import { makeLLM } from '../minimax'
+
+/**
+ * Integration tests for MiniMax LLM provider.
+ * Requires MINIMAX_API_KEY environment variable.
+ * Run with: MINIMAX_API_KEY=<key> npx vitest run --reporter=verbose minimax-integration
+ */
+describe('MiniMax integration', () => {
+  const apiKey = process.env.MINIMAX_API_KEY
+
+  it.skipIf(!apiKey)('should invoke MiniMax-M2.7 and return a response', async () => {
+    const llm = makeLLM({ minimax: apiKey, temp: 0.1, max_tokens: 256 })
+    const result = await llm.invoke([
+      { role: 'user', content: 'Reply with exactly: hello world' },
+    ])
+    expect(result).toBeDefined()
+    expect(typeof result.content).toBe('string')
+    expect(result.content.toLowerCase()).toContain('hello')
+  }, 30000)
+
+  it.skipIf(!apiKey)('should invoke MiniMax-M2.5-highspeed model', async () => {
+    const llm = makeLLM({
+      minimax: apiKey,
+      minimax_model: 'MiniMax-M2.5-highspeed',
+      temp: 0.1,
+      max_tokens: 128,
+    })
+    const result = await llm.invoke([
+      { role: 'user', content: 'What is 2+2? Answer with just the number.' },
+    ])
+    expect(result).toBeDefined()
+    expect(result.content).toContain('4')
+  }, 30000)
+
+  it.skipIf(!apiKey)('should work with call() method (alias for invoke)', async () => {
+    const llm = makeLLM({ minimax: apiKey, temp: 0.1, max_tokens: 128 })
+    const result = await llm.call([
+      { role: 'user', content: 'Say "ok"' },
+    ])
+    expect(result).toBeDefined()
+    expect(typeof result.content).toBe('string')
+  }, 30000)
+})

--- a/backend/src/utils/llm/models/__tests__/minimax.test.ts
+++ b/backend/src/utils/llm/models/__tests__/minimax.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock @langchain/openai before importing minimax module
+vi.mock('@langchain/openai', () => {
+  const MockChatOpenAI = vi.fn(function (this: any, opts: any) {
+    this.invoke = vi.fn().mockResolvedValue({ content: 'mock response' })
+    this._opts = opts
+  })
+  const MockOpenAIEmbeddings = vi.fn(function (this: any, opts: any) {
+    this.embedDocuments = vi.fn().mockResolvedValue([[0.1, 0.2]])
+    this.embedQuery = vi.fn().mockResolvedValue([0.1, 0.2])
+    this._opts = opts
+  })
+  return { ChatOpenAI: MockChatOpenAI, OpenAIEmbeddings: MockOpenAIEmbeddings }
+})
+
+import { ChatOpenAI, OpenAIEmbeddings } from '@langchain/openai'
+import { makeLLM, makeEmbeddings } from '../minimax'
+
+describe('MiniMax LLM provider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('makeLLM', () => {
+    it('should create a ChatOpenAI instance with MiniMax defaults', () => {
+      const cfg = { minimax: 'test-api-key' }
+      const llm = makeLLM(cfg)
+
+      expect(ChatOpenAI).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: 'MiniMax-M2.7',
+          apiKey: 'test-api-key',
+          configuration: { baseURL: 'https://api.minimax.io/v1' },
+        }),
+      )
+      expect(llm).toHaveProperty('invoke')
+      expect(llm).toHaveProperty('call')
+    })
+
+    it('should use configured model when provided', () => {
+      const cfg = { minimax: 'key', minimax_model: 'MiniMax-M2.5-highspeed' }
+      makeLLM(cfg)
+
+      expect(ChatOpenAI).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: 'MiniMax-M2.5-highspeed',
+        }),
+      )
+    })
+
+    it('should clamp temperature to [0, 1]', () => {
+      const cfg = { minimax: 'key', temp: 2.5 }
+      makeLLM(cfg)
+
+      expect(ChatOpenAI).toHaveBeenCalledWith(
+        expect.objectContaining({
+          temperature: 1,
+        }),
+      )
+    })
+
+    it('should handle temperature of 0', () => {
+      const cfg = { minimax: 'key', temp: 0 }
+      makeLLM(cfg)
+
+      expect(ChatOpenAI).toHaveBeenCalledWith(
+        expect.objectContaining({
+          temperature: 0,
+        }),
+      )
+    })
+
+    it('should default temperature to 0.7 when not set', () => {
+      const cfg = { minimax: 'key' }
+      makeLLM(cfg)
+
+      expect(ChatOpenAI).toHaveBeenCalledWith(
+        expect.objectContaining({
+          temperature: 0.7,
+        }),
+      )
+    })
+
+    it('should pass max_tokens from config', () => {
+      const cfg = { minimax: 'key', max_tokens: 4096 }
+      makeLLM(cfg)
+
+      expect(ChatOpenAI).toHaveBeenCalledWith(
+        expect.objectContaining({
+          maxTokens: 4096,
+        }),
+      )
+    })
+
+    it('should read MINIMAX_API_KEY from env when cfg.minimax is empty', () => {
+      process.env.MINIMAX_API_KEY = 'env-key'
+      const cfg = {} as any
+      makeLLM(cfg)
+
+      expect(ChatOpenAI).toHaveBeenCalledWith(
+        expect.objectContaining({
+          apiKey: 'env-key',
+        }),
+      )
+      delete process.env.MINIMAX_API_KEY
+    })
+
+    it('should return an object with invoke and call methods', async () => {
+      const cfg = { minimax: 'key' }
+      const llm = makeLLM(cfg)
+
+      expect(typeof llm.invoke).toBe('function')
+      expect(typeof llm.call).toBe('function')
+
+      const result = await llm.invoke([{ role: 'user', content: 'Hello' }])
+      expect(result).toEqual({ content: 'mock response' })
+    })
+
+    it('should handle negative temperature by clamping to 0', () => {
+      const cfg = { minimax: 'key', temp: -1 }
+      makeLLM(cfg)
+
+      expect(ChatOpenAI).toHaveBeenCalledWith(
+        expect.objectContaining({
+          temperature: 0,
+        }),
+      )
+    })
+  })
+
+  describe('makeEmbeddings', () => {
+    it('should create OpenAI embeddings as fallback', () => {
+      const cfg = { openai: 'oai-key' }
+      const emb = makeEmbeddings(cfg)
+
+      expect(OpenAIEmbeddings).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: 'text-embedding-3-large',
+          apiKey: 'oai-key',
+        }),
+      )
+      expect(emb).toHaveProperty('embedDocuments')
+      expect(emb).toHaveProperty('embedQuery')
+    })
+
+    it('should use configured embed model', () => {
+      const cfg = { openai: 'oai-key', openai_embed_model: 'text-embedding-3-small' }
+      makeEmbeddings(cfg)
+
+      expect(OpenAIEmbeddings).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: 'text-embedding-3-small',
+        }),
+      )
+    })
+
+    it('should read OPENAI_API_KEY from env when cfg.openai is empty', () => {
+      process.env.OPENAI_API_KEY = 'env-oai-key'
+      const cfg = {} as any
+      makeEmbeddings(cfg)
+
+      expect(OpenAIEmbeddings).toHaveBeenCalledWith(
+        expect.objectContaining({
+          apiKey: 'env-oai-key',
+        }),
+      )
+      delete process.env.OPENAI_API_KEY
+    })
+  })
+})

--- a/backend/src/utils/llm/models/index.ts
+++ b/backend/src/utils/llm/models/index.ts
@@ -4,6 +4,7 @@ import * as openai from './openai'
 import * as grok from './grok'
 import * as claude from './claude'
 import * as openrouter from './openrouter'
+import * as minimax from './minimax'
 import { config } from '../../../config/env'
 import type { EmbeddingsLike, LLM } from './types'
 
@@ -17,6 +18,7 @@ function pick(p: string) {
     case 'grok': return grok
     case 'claude': return claude
     case 'openrouter': return openrouter
+    case 'minimax': return minimax
     default: return gemini
   }
 }

--- a/backend/src/utils/llm/models/minimax.ts
+++ b/backend/src/utils/llm/models/minimax.ts
@@ -1,0 +1,22 @@
+import { ChatOpenAI, OpenAIEmbeddings } from '@langchain/openai'
+import { wrapChat } from './util'
+import type { MkLLM, MkEmb, EmbeddingsLike } from './types'
+
+export const makeLLM: MkLLM = (cfg: any) => {
+  const temp = cfg.temp ?? 0.7
+  const m = new ChatOpenAI({
+    model: cfg.minimax_model || 'MiniMax-M2.7',
+    apiKey: cfg.minimax || process.env.MINIMAX_API_KEY,
+    configuration: { baseURL: 'https://api.minimax.io/v1' },
+    temperature: Math.max(0, Math.min(temp, 1)),
+    maxTokens: cfg.max_tokens,
+  })
+  return wrapChat(m)
+}
+
+export const makeEmbeddings: MkEmb = (cfg: any): EmbeddingsLike => {
+  return new OpenAIEmbeddings({
+    model: cfg.openai_embed_model || 'text-embedding-3-large',
+    apiKey: cfg.openai || process.env.OPENAI_API_KEY,
+  })
+}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "scripts": {
     "dev": "nodemon",
     "build": "tsc -p backend/tsconfig.json",
-    "start": "node backend/dist/src/core/index.js"
+    "start": "node backend/dist/src/core/index.js",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "authors": [
     "nullure (https://github.com/nullure)",
@@ -44,7 +46,8 @@
     "@types/node": "^24.5.1",
     "ts-node": "^10.9.2",
     "tsx": "^4.20.5",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "vitest": "^4.1.1"
   },
   "overrides": {
     "expr-eval": "npm:expr-eval-fork@^3.0.0",


### PR DESCRIPTION
## Summary

Adds [MiniMax](https://www.minimax.io/) as the 7th LLM provider alongside Gemini, OpenAI, Claude, Grok, Ollama, and OpenRouter.

MiniMax provides an OpenAI-compatible API with high-capability models:
- **MiniMax-M2.7** (default) — latest model with 1M context window
- **MiniMax-M2.5-highspeed** — 204K context, faster inference

## Changes

- **New file**: `backend/src/utils/llm/models/minimax.ts` — MiniMax provider using `ChatOpenAI` from `@langchain/openai` with MiniMax base URL
- **Updated**: `backend/src/utils/llm/models/index.ts` — added `minimax` case to the factory `pick()` switch
- **Updated**: `backend/src/config/env.ts` — added `MINIMAX_API_KEY` and `MINIMAX_MODEL` config vars
- **Updated**: `.env.example` — added MiniMax configuration section
- **Updated**: `README.md` — added MiniMax to supported AI models list
- **Updated**: `package.json` — added vitest + test scripts
- **New tests**: 15 unit tests + 3 integration tests

## How it works

MiniMax uses the OpenAI-compatible API format, so it reuses the existing `ChatOpenAI` class from `@langchain/openai` (already a dependency). Temperature is clamped to `[0, 1]` per MiniMax API constraints. Embeddings fall back to OpenAI (same pattern as Claude and Grok providers).

## Configuration

```env
LLM_PROVIDER=minimax
MINIMAX_API_KEY=your-api-key
MINIMAX_MODEL=MiniMax-M2.7
```

## Test plan

- [x] 9 unit tests for `makeLLM()` — model selection, temp clamping, env fallback, API key handling
- [x] 3 unit tests for `makeEmbeddings()` — OpenAI fallback, model config, env fallback
- [x] 3 factory integration tests — provider selection, embedding fallback, non-selection
- [x] 3 integration tests — real API calls to MiniMax-M2.7 and M2.5-highspeed

Run tests:
```bash
npm install --legacy-peer-deps
npx vitest run --reporter=verbose
```