### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,7 +66,7 @@ GROK_BASE=https://api.x.ai/v1
 # MiniMax
 ########################################
 MINIMAX_API_KEY=
-MINIMAX_MODEL=MiniMax-M2.7
+MINIMAX_MODEL=MiniMax-M3
 
 ########################################
 # Ollama (local models)

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -23,7 +23,7 @@ export const config = {
   grok_model: process.env.GROK_MODEL || 'grok-2-latest',
   grok_base: process.env.GROK_BASE || 'https://api.x.ai/v1',
   minimax: process.env.MINIMAX_API_KEY || '',
-  minimax_model: process.env.MINIMAX_MODEL || 'MiniMax-M2.7',
+  minimax_model: process.env.MINIMAX_MODEL || 'MiniMax-M3',
   ollama: {
     model: process.env.OLLAMA_MODEL || 'llama4',
     embedModel: process.env.OLLAMA_EMBED_MODEL || '',

--- a/backend/src/utils/llm/models/__tests__/minimax-integration.test.ts
+++ b/backend/src/utils/llm/models/__tests__/minimax-integration.test.ts
@@ -9,7 +9,7 @@ import { makeLLM } from '../minimax'
 describe('MiniMax integration', () => {
   const apiKey = process.env.MINIMAX_API_KEY
 
-  it.skipIf(!apiKey)('should invoke MiniMax-M2.7 and return a response', async () => {
+  it.skipIf(!apiKey)('should invoke MiniMax-M3 and return a response', async () => {
     const llm = makeLLM({ minimax: apiKey, temp: 0.1, max_tokens: 256 })
     const result = await llm.invoke([
       { role: 'user', content: 'Reply with exactly: hello world' },
@@ -19,10 +19,10 @@ describe('MiniMax integration', () => {
     expect(result.content.toLowerCase()).toContain('hello')
   }, 30000)
 
-  it.skipIf(!apiKey)('should invoke MiniMax-M2.5-highspeed model', async () => {
+  it.skipIf(!apiKey)('should invoke MiniMax-M2.7-highspeed model', async () => {
     const llm = makeLLM({
       minimax: apiKey,
-      minimax_model: 'MiniMax-M2.5-highspeed',
+      minimax_model: 'MiniMax-M2.7-highspeed',
       temp: 0.1,
       max_tokens: 128,
     })

--- a/backend/src/utils/llm/models/__tests__/minimax.test.ts
+++ b/backend/src/utils/llm/models/__tests__/minimax.test.ts
@@ -29,7 +29,7 @@ describe('MiniMax LLM provider', () => {
 
       expect(ChatOpenAI).toHaveBeenCalledWith(
         expect.objectContaining({
-          model: 'MiniMax-M2.7',
+          model: 'MiniMax-M3',
           apiKey: 'test-api-key',
           configuration: { baseURL: 'https://api.minimax.io/v1' },
         }),
@@ -39,12 +39,12 @@ describe('MiniMax LLM provider', () => {
     })
 
     it('should use configured model when provided', () => {
-      const cfg = { minimax: 'key', minimax_model: 'MiniMax-M2.5-highspeed' }
+      const cfg = { minimax: 'key', minimax_model: 'MiniMax-M2.7-highspeed' }
       makeLLM(cfg)
 
       expect(ChatOpenAI).toHaveBeenCalledWith(
         expect.objectContaining({
-          model: 'MiniMax-M2.5-highspeed',
+          model: 'MiniMax-M2.7-highspeed',
         }),
       )
     })

--- a/backend/src/utils/llm/models/minimax.ts
+++ b/backend/src/utils/llm/models/minimax.ts
@@ -5,7 +5,7 @@ import type { MkLLM, MkEmb, EmbeddingsLike } from './types'
 export const makeLLM: MkLLM = (cfg: any) => {
   const temp = cfg.temp ?? 0.7
   const m = new ChatOpenAI({
-    model: cfg.minimax_model || 'MiniMax-M2.7',
+    model: cfg.minimax_model || 'MiniMax-M3',
     apiKey: cfg.minimax || process.env.MINIMAX_API_KEY,
     configuration: { baseURL: 'https://api.minimax.io/v1' },
     temperature: Math.max(0, Math.min(temp, 1)),


### PR DESCRIPTION
## Summary
Upgrade the MiniMax provider configuration to include the latest M3 model as the new default, while keeping M2.7 (and the M2.7-highspeed variant) as an available alternative for users who need the previous generation.

## Changes
- Default `minimax_model` is now `MiniMax-M3` in `backend/src/utils/llm/models/minimax.ts` and `backend/src/config/env.ts`
- `.env.example` documents `MINIMAX_MODEL=MiniMax-M3`
- Unit and integration tests updated to assert the new default and to use the `MiniMax-M2.7-highspeed` variant for the alternative-model case
- Older versions (`M2.5` / `M2.1` / `M2` / `M1`) are no longer referenced anywhere

## Why
MiniMax-M3 is the new flagship model with 512K context window, 128K max output and image input support across both OpenAI-compatible and Anthropic-compatible interfaces. M2.7 stays available so existing users can keep their previous configuration without changes.

## Testing
- `npm run build` — passes
- `npm test` — 15 passed / 3 skipped (the 3 skipped are integration tests that require `MINIMAX_API_KEY`)