### PR TITLE
Align Node.js version references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v5
       with:
-        node-version: '20.x'
+        node-version: '21.x'
     
     - name: Install dependencies (backend)
       run: npm install

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v5
       with:
-        node-version: '20.x'
+        node-version: '21.x'
     
     - name: Setup pnpm
       uses: pnpm/action-setup@v4
@@ -87,7 +87,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v5
       with:
-        node-version: '20.x'
+        node-version: '21.x'
     
     - name: Setup pnpm
       uses: pnpm/action-setup@v4

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 <p align="center">
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-PageLM%20Community%20License-blueviolet.svg" alt="License: PageLM Community License"></a>
-  <a href="https://nodejs.org/"><img src="https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen.svg" alt="Node.js Version"></a>
+  <a href="https://nodejs.org/"><img src="https://img.shields.io/badge/node-%3E%3D21.18.0-brightgreen.svg" alt="Node.js Version"></a>
   <a href="https://reactjs.org/"><img src="https://img.shields.io/badge/React-18+-blue.svg" alt="React"></a>
   <a href="https://www.typescriptlang.org/"><img src="https://img.shields.io/badge/TypeScript-5.0+-blue.svg" alt="TypeScript"></a>
   <a href="https://discord.gg/P7HaRayqTh"><img alt="Discord" src="https://img.shields.io/discord/1379682804849180844?label=Discord%20server"></a>


### PR DESCRIPTION
Summary:
- Update the README Node.js badge to match the documented Node.js 21.18 or newer requirement.
- Align dependency-check and security workflow Node.js setup steps with the existing Node 21 CI matrix and package engine.

Why:
package.json and the README prerequisites require Node.js 21.18 or newer, but the README badge and two workflow jobs still referenced Node 20. Keeping these in sync avoids contributor setup confusion and prevents CI jobs from running below the declared engine requirement.

Verification:
- rg checked Node version references across README.md, package.json, and .github/workflows.
- git diff --check passed.